### PR TITLE
rename docker

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -41,18 +41,18 @@ jobs:
         echo
         echo
         echo "Pushing docker to ghcr.io!"
-        docker tag iglu-builder-docker:$version-arm64 ghcr.io/iglu-sh/iglu-builder-docker:$version-arm64 
-        docker tag iglu-builder-docker:$version-amd64 ghcr.io/iglu-sh/iglu-builder-docker:$version-amd64 
-        docker push ghcr.io/iglu-sh/iglu-builder-docker:$version-arm64 
-        docker push ghcr.io/iglu-sh/iglu-builder-docker:$version-amd64 
+        docker tag iglu-builder-docker:$version-arm64 ghcr.io/iglu-sh/iglu-builder:$version-arm64 
+        docker tag iglu-builder-docker:$version-amd64 ghcr.io/iglu-sh/iglu-builder:$version-amd64 
+        docker push ghcr.io/iglu-sh/iglu-builder:$version-arm64 
+        docker push ghcr.io/iglu-sh/iglu-builder:$version-amd64 
 
         for tag in latest $version; do
           echo
           echo
           echo "Creating multiarch image for $tag!"
-          docker manifest create ghcr.io/iglu-sh/iglu-builder-docker:$tag \
-          --amend ghcr.io/iglu-sh/iglu-builder-docker:$version-amd64 \
-          --amend ghcr.io/iglu-sh/iglu-builder-docker:$version-arm64
-          docker manifest push ghcr.io/iglu-sh/iglu-builder-docker:$tag
+          docker manifest create ghcr.io/iglu-sh/iglu-builder:$tag \
+          --amend ghcr.io/iglu-sh/iglu-builder:$version-amd64 \
+          --amend ghcr.io/iglu-sh/iglu-builder:$version-arm64
+          docker manifest push ghcr.io/iglu-sh/iglu-builder:$tag
         done
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,28 @@
-# iglu-builder
+# Iglu Builder
+[![Build Image and upload to ghcr](https://github.com/iglu-sh/builder/actions/workflows/build-docker.yml/badge.svg)](https://github.com/iglu-sh/builder/actions/workflows/build-docker.yml)
+[![CodeQL](https://github.com/iglu-sh/builder/actions/workflows/codeql.yml/badge.svg)](https://github.com/iglu-sh/builder/actions/workflows/codeql.yml)
 
-To install dependencies:
+The builder compoment of the Iglu project. It's a simple nix builder that can be used to build and push derivations to a cachix compatible Cache. ([Iglu Cache](https://github.com/iglu-sh/cache))
+
+## Installation
+Normally you don't have to setup the builder manually. The [Iglu Controller](https://github.com/iglu-sh/controller) spins up new builder each time it starts a job. If you want to spin up a builder manually anyway then you can use:
+
+```bash
+docker run --rm ghcr.io/iglu-sh/iglu-builder-docker:latest
+```
+
+## Documentation
+Documentation of the build could be found [here](https://docs.iglu.sh/docs/Components/Iglu%20Builder).
+
+## Development
+For development you need a working installation of [Bun](https://bun.sh).
+The simplest way to get a working development-environment is to us `nix develop` at the top of the repository.
+
+**IMPORTANT:** If you want to build the docker image you have to run `nix build .#iglu-builder-docker && docker load < result`.
 
 ```bash
 bun install
-```
-
-To run:
-
-```bash
-bun run index.ts
+bun run prod
 ```
 
 This project was created using `bun init` in bun v1.2.12. [Bun](https://bun.sh) is a fast all-in-one JavaScript runtime.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The builder compoment of the Iglu project. It's a simple nix builder that can be
 Normally you don't have to setup the builder manually. The [Iglu Controller](https://github.com/iglu-sh/controller) spins up new builder each time it starts a job. If you want to spin up a builder manually anyway then you can use:
 
 ```bash
-docker run --rm ghcr.io/iglu-sh/iglu-builder-docker:latest
+docker run --rm ghcr.io/iglu-sh/iglu-builder:latest
 ```
 
 ## Documentation

--- a/nix/pkgs/iglu-builder-docker/default.nix
+++ b/nix/pkgs/iglu-builder-docker/default.nix
@@ -8,7 +8,7 @@ let
   archType = if (stdenv.hostPlatform.system == "x86_64-linux") then "amd64" else "arm64";
 in
 dockerTools.buildImage {
-  name = "iglu-builder-docker";
+  name = "iglu-builder";
   tag = "v${iglu.iglu-builder.version}-${archType}";
 
   copyToRoot = [


### PR DESCRIPTION
renames the docker from `iglu-builder-docker` to `iglu-builder` as the docker is redundant in the name