### PR TITLE
add nixbld group in docker

### DIFF
--- a/nix/pkgs/iglu-builder-docker/default.nix
+++ b/nix/pkgs/iglu-builder-docker/default.nix
@@ -4,7 +4,6 @@
 , coreutils
 , buildEnv
 , tini
-, runtimeShell
 , nix
 , cachix
 , stdenv

--- a/nix/pkgs/iglu-builder-docker/default.nix
+++ b/nix/pkgs/iglu-builder-docker/default.nix
@@ -4,7 +4,7 @@
 , coreutils
 , buildEnv
 , tini
-, cacert
+, runtimeShell
 , nix
 , cachix
 , stdenv
@@ -19,16 +19,24 @@ dockerTools.buildImage {
 
   copyToRoot = buildEnv {
     name = "image-root";
-    paths = [
+    paths = with dockerTools; [
       iglu.iglu-builder
       bash
       coreutils
       nix
       cachix
-      cacert
       tini
+      caCertificates
+      (fakeNss.override {
+        extraPasswdLines = [
+          "nixbld:x:3000:3000:Build user:/var/empty:/noshell"
+        ];
+        extraGroupLines = [
+          "nixbld:x:3000:"
+        ];
+      })
     ];
-    pathsToLink = [ "/bin" "/etc" ];
+    pathsToLink = [ "/bin" "/etc" "/var" ];
   };
 
   config = {
@@ -36,6 +44,5 @@ dockerTools.buildImage {
       "3000/tcp" = { };
     };
     Cmd = [ "/bin/tini" "--" "/bin/iglu-builder" ];
-    Env = [ "SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt" ];
   };
 }


### PR DESCRIPTION
Fixes a build issue where this error comes up:
![image](https://github.com/user-attachments/assets/66ced036-7d20-4a32-96f4-1e3858438949)

+ clean up of the ca certs.